### PR TITLE
feat:  Replaces tag to overwrite ros-kinetic-control-toolbox feature

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,5 +9,6 @@ Standards-Version: 3.9.2
 Package: ros-kinetic-am-control-toolbox
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, libtinyxml-dev, ros-kinetic-cmake-modules, ros-kinetic-control-msgs, ros-kinetic-dynamic-reconfigure, ros-kinetic-message-runtime, ros-kinetic-realtime-tools, ros-kinetic-roscpp, ros-kinetic-std-msgs, ros-kinetic-control-msgs
+Replaces: ros-kinetic-control-toolbox
 Description: The control toolbox contains modules that are useful across all controllers.
 


### PR DESCRIPTION
feat: Uses the Replaces tag in debian/control